### PR TITLE
add ping and set retrys explicitly for mongo client

### DIFF
--- a/mongodb/client/client.go
+++ b/mongodb/client/client.go
@@ -2,8 +2,9 @@ package client
 
 import (
 	"context"
-	config "github.com/Trendyol/go-dcp-mongodb/configs"
 	"time"
+
+	config "github.com/Trendyol/go-dcp-mongodb/configs"
 
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -12,7 +13,11 @@ import (
 func NewMongoClient(cfg config.MongoDB) (*mongo.Client, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+
 	clientOpts := options.Client().ApplyURI("mongodb://" + cfg.URI)
+	clientOpts.SetRetryWrites(true)
+	clientOpts.SetRetryReads(true)
+
 	if cfg.Username != "" && cfg.Password != "" {
 		clientOpts.SetAuth(options.Credential{
 			Username:   cfg.Username,
@@ -20,9 +25,19 @@ func NewMongoClient(cfg config.MongoDB) (*mongo.Client, error) {
 			AuthSource: cfg.Database,
 		})
 	}
+
 	client, err := mongo.Connect(ctx, clientOpts)
 	if err != nil {
 		return nil, err
 	}
+
+	pingCtx, pingCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer pingCancel()
+
+	if err = client.Ping(pingCtx, nil); err != nil {
+		client.Disconnect(ctx)
+		return nil, err
+	}
+
 	return client, nil
 }

--- a/mongodb/client/client.go
+++ b/mongodb/client/client.go
@@ -35,7 +35,11 @@ func NewMongoClient(cfg config.MongoDB) (*mongo.Client, error) {
 	defer pingCancel()
 
 	if err = client.Ping(pingCtx, nil); err != nil {
-		client.Disconnect(ctx)
+		errDisc := client.Disconnect(ctx)
+		if errDisc != nil {
+			return nil, errDisc
+		}
+
 		return nil, err
 	}
 


### PR DESCRIPTION
1-
Ping the database before connecting to mongodb.

2-
set the retry explicitly for older versions of mongodb
https://www.mongodb.com/docs/v7.0/core/retryable-reads/
https://www.mongodb.com/docs/v7.0/core/retryable-writes/
